### PR TITLE
Order event updates by latest first

### DIFF
--- a/scripts/lib/event_parser.js
+++ b/scripts/lib/event_parser.js
@@ -70,7 +70,7 @@ function massageEvent(data) {
 
   // sort updates and attach them
   o.updates = updates.sort(function(l,r) {
-    return l.when > r.when;
+    return l.when < r.when;
   });
 
   return o;


### PR DESCRIPTION
Events are ordered by latest event at the top, so I think it would be clearer if the updates within an event also were ordered so.

Currently it looks like this:

<img width="400" src="https://cloud.githubusercontent.com/assets/660706/4752432/56f9c8fa-5aab-11e4-8d27-8119987f661d.png">

This PR changes it to:

<img width="400" src="https://cloud.githubusercontent.com/assets/660706/4752441/6d44887a-5aab-11e4-9f07-fabaae63f21d.png">

What do you think?
